### PR TITLE
Ignore CSS classes

### DIFF
--- a/src/Server/js/caliban.js
+++ b/src/Server/js/caliban.js
@@ -1747,7 +1747,7 @@ if (typeof window.Caliban !== 'object') {
              */
 			function getClassesRegExp(configClasses, defaultClass) {
 				var i,
-					classesRegExp = '(^| )(caliban[_-]' + defaultClass;
+					classesRegExp = '(^| )(cbn[_-]' + defaultClass;
 
 				if (configClasses) {
 					for (i = 0; i < configClasses.length; i++) {
@@ -2748,7 +2748,7 @@ if (typeof window.Caliban !== 'object') {
 		 * Constructor
 		 ************************************************************/
 
-		var applyFirst = ['setTrackerUrl', 'enableCrossDomainLinking', 'setSessionTimeout', 'setSecureCookie', 'setCookiePath', 'setCookieDomain', 'setDomains', 'setDebugForms', 'setPropertyId', 'setSessionIdParam', 'setAppendParams', 'enableLinkTracking'];
+		var applyFirst = ['setTrackerUrl', 'enableCrossDomainLinking', 'setSessionTimeout', 'setSecureCookie', 'setCookiePath', 'setCookieDomain', 'setDomains', 'setDebugForms', 'setPropertyId', 'setSessionIdParam', 'setAppendParams', 'setIgnoreClasses', 'enableLinkTracking'];
 
 		/************************************************************
 		 * Public data and methods


### PR DESCRIPTION
- CSS ignore classes for link append was being set after the event click listeners were established so updated this API call firing order
- Changed the default ignore class from `caliban-ignore` to `cbn-ignore` to match other uses of this acronym in client API