### PR TITLE
Form data on load

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,11 +8,11 @@
     "packages": [
         {
             "name": "itcig/php-helpers",
-            "version": "v1.0.0",
+            "version": "v1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/itcig/php-helpers.git",
-                "reference": "0e684882b93b99e35a3ea94f630c39d49ca5bd11"
+                "reference": "30dd0e78c8f45343916f94249a92a1628ea2cf4c"
             },
             "require": {
                 "php": "^7.1"
@@ -33,7 +33,7 @@
                 }
             ],
             "description": "PHP helper methods",
-            "time": "2020-03-24T12:59:22+00:00"
+            "time": "2020-03-26T03:39:23+00:00"
         },
         {
             "name": "oscarotero/env",

--- a/src/Server/Server.php
+++ b/src/Server/Server.php
@@ -104,7 +104,7 @@ class Server extends Singleton {
 
 			// Send session data to JS tracker and add data to forms
 			print "window._cbn.push(['setSessionData', " . \Cig\to_javascript_object($caliban_data) . "]);\n";
-			print "window._cbn.push(['addSubmitListeners']);\n";
+			print "window._cbn.push(['addFormData']);\n";
 
 		// Otherwise send back a text response
 		} else {

--- a/src/Server/js/caliban.js
+++ b/src/Server/js/caliban.js
@@ -2135,6 +2135,41 @@ if (typeof window.Caliban !== 'object') {
 				}
 			}
 
+			/*
+             * Add submit handlers to FORM elements, except those to be ignored
+             */
+			function addFormData(trackerInstance) {
+				// iterate through FORM elements
+				var i,
+					ignorePattern = getClassesRegExp(configIgnoreClasses, 'ignore'),
+					formElements = documentAlias.forms,
+					formElement = null, trackerType = null;
+
+				if (formElements) {
+					for (i = 0; i < formElements.length; i++) {
+						formElement = formElements[i];
+						if (!ignorePattern.test(formElement.className)) {
+							trackerType = typeof formElement.calibanTrackers;
+
+							if ('undefined' === trackerType) {
+								formElement.calibanTrackers = [];
+							}
+
+							if (-1 === indexOfArray(formElement.calibanTrackers, trackerInstance)) {
+								// we make sure to setup form only once for each tracker
+								formElement.calibanTrackers.push(trackerInstance);
+
+								// Add event listeners to relevant forms onSubmit
+								// addSubmitListener(formElement);
+
+								// Appened form params onInit and not onSubmit to allow working on forms
+								addFormParams(target);
+							}
+						}
+					}
+				}
+			}
+
 			/************************************************************
 			 * Constructor
 			 ************************************************************/
@@ -2631,15 +2666,19 @@ if (typeof window.Caliban !== 'object') {
 			};
 
 			/**
-			 * Add click listener to a specific link element.
-			 * When clicked, Caliban will log the click automatically.
-			 *
-			 * @param DOMElement element
-			 * @param bool enable If false, do not use pseudo click-handler (middle click + context menu)
+			 * Add submit listeners to all non-excluded form elements.
 			 */
 			this.addSubmitListeners = function () {
 				addSubmitListeners();
 			};
+
+			/**
+			 * Add all caliban data as hidden form fields to all non-excluded form elements.
+			 */
+			this.addFormData = function () {
+				addFormData();
+			};
+
 
 			/**
 			 * Install link tracker.


### PR DESCRIPTION
- Append form field session data on load instead of `onSubmit` event listener to accommodate forms which are submitted via click events or other non-traditional JS submissions.  
- Updated [php-helpers](https://github.com/itcig/php-helpers)