### PR TITLE
Config changes to global constants

### DIFF
--- a/src/Caliban.php
+++ b/src/Caliban.php
@@ -244,17 +244,17 @@ class Caliban extends Singleton {
 
 		// List of keys in request querystring that are allowed to write to session cache
 		if (empty($this->append_params)) {
-			$this->append_params = defined('APPEND_PARAMS') ? APPEND_PARAMS : [];
+			$this->append_params = defined('CBN_APPEND_PARAMS') ? CBN_APPEND_PARAMS : [];
 		}
 
 		// List keys we should ignore in session cache if found in the request
 		if (empty($this->ignore_params)) {
-			$this->ignore_params = defined('IGNORE_PARAMS') ? IGNORE_PARAMS : [];
+			$this->ignore_params = defined('CBN_IGNORE_PARAMS') ? CBN_IGNORE_PARAMS : [];
 		}
 
 		// Default list of params that are always first attribution without exception
 		if (empty($this->first_attribution_params)) {
-			$this->first_attribution_params = defined('FIRST_ATTRIBUTION_PARAMS') ? FIRST_ATTRIBUTION_PARAMS : [];
+			$this->first_attribution_params = defined('CBN_FIRST_ATTRIBUTION_PARAMS') ? CBN_FIRST_ATTRIBUTION_PARAMS : [];
 		}
 
 		// We will populate this during init()

--- a/src/config.php
+++ b/src/config.php
@@ -19,40 +19,50 @@ if (file_exists($root_dir . '/.env')) {
 }
 
 // TODO: Make this dynamically read off whether the cigsession_chrome plugin is enabled
-define('CBN_DEBUG', env('CBN_DEBUG'));
+if (!defined('CBN_DEBUG')) {
+	define('CBN_DEBUG', env('CBN_DEBUG') ?? false);
+}
 
 /**
  * Cookie and tracking variable settings
  */
-define('CBN_SESSION_REFERENCE_KEY', env('CBN_SESSION_REFERENCE_KEY') ?? "_cbnsid");
-define('CBN_DEFAULT_CACHE_KEY', env('CBN_DEFAULT_CACHE_KEY') ?? "cbn");
+if (!defined('CBN_SESSION_REFERENCE_KEY')) {
+	define('CBN_SESSION_REFERENCE_KEY', env('CBN_SESSION_REFERENCE_KEY') ?? "_cbnsid");
+}
+
+if (!defined('CBN_DEFAULT_CACHE_KEY')) {
+	define('CBN_DEFAULT_CACHE_KEY', env('CBN_DEFAULT_CACHE_KEY') ?? "cbn");
+}
 
 /**
  * Redis connection
  * Stored as strings so this can be offloaded to ENV
  */
-define('CBN_REDIS_SERVERS', env('CBN_REDIS_SERVERS'));
+if (!defined('CBN_REDIS_SERVERS')) {
+	define('CBN_REDIS_SERVERS', env('CBN_REDIS_SERVERS') ?? null);
+}
 
-if (Cig\is_json(env('CBN_REDIS_OPTIONS'))) {
+if (!defined('CBN_REDIS_OPTIONS') && Cig\is_json(env('CBN_REDIS_OPTIONS'))) {
 	define('CBN_REDIS_OPTIONS', json_decode(env('CBN_REDIS_OPTIONS'), true));
 }
 
-define('CBN_CACHE_EXPIRATION', 2 * 60 * 60); // 2 hours
-
+if (!defined('CBN_CACHE_EXPIRATION')) {
+	define('CBN_CACHE_EXPIRATION', 2 * 60 * 60); // 2 hours
+}
 
 /**
  * Append data to outbound links and forms
  */
 
 // Allow setting array of params to append to all links and outbound URLs
-if (!empty(env('CBN_APPEND_PARAMS'))) {
+if (!defined('CBN_APPEND_PARAMS') && !empty(env('CBN_APPEND_PARAMS'))) {
 	// Convert to an array
 	$append_params = explode(",", env('CBN_APPEND_PARAMS'));
 
 	// Remove whitespace
 	array_walk($append_params, 'trim');
 
-	define('APPEND_PARAMS', $append_params);
+	define('CBN_APPEND_PARAMS', $append_params);
 }
 
 /**
@@ -60,26 +70,26 @@ if (!empty(env('CBN_APPEND_PARAMS'))) {
  */
 
 // Allow setting array of params to ignore from tracking data, otherwise use defaults
-if (!empty(env('CBN_IGNORE_PARAMS'))) {
+if (!defined('CBN_IGNORE_PARAMS') && !empty(env('CBN_IGNORE_PARAMS'))) {
 	// Convert to an array
 	$ignore_params = explode(",", env('CBN_IGNORE_PARAMS'));
 
 	// Remove whitespace
 	array_walk($ignore_params, 'trim');
 
-	define('IGNORE_PARAMS', $ignore_params);
+	define('CBN_IGNORE_PARAMS', $ignore_params);
 }
 
 
 /**
  * First attribution params
  */
-if (!empty(env('CBN_FIRST_ATTRIBUTION_PARAMS'))) {
+if (!defined('CBN_FIRST_ATTRIBUTION_PARAMS') && !empty(env('CBN_FIRST_ATTRIBUTION_PARAMS'))) {
 	// Convert to an array
 	$first_attribution_params = explode(",", env('CBN_FIRST_ATTRIBUTION_PARAMS'));
 
 	// Remove whitespace
 	array_walk($first_attribution_params, 'trim');
 
-	define('FIRST_ATTRIBUTION_PARAMS', $first_attribution_params);
+	define('CBN_FIRST_ATTRIBUTION_PARAMS', $first_attribution_params);
 }


### PR DESCRIPTION
- Allow global constants to be defined from the application that is loading Caliban
- This requires checking `defined()` everywhere we initiate these