### PR TITLE
Append form data to async forms

### DIFF
--- a/src/Server/js/caliban.js
+++ b/src/Server/js/caliban.js
@@ -2166,7 +2166,8 @@ if (typeof window.Caliban !== 'object') {
 			}
 
 			/*
-             * Add submit handlers to FORM elements, except those to be ignored
+             * Add session data as hidden inputs to FORM elements, except those set to be ignored.
+             * This can be called repeatedly on the same form as session data may change or a form may be rendered after initial DOM load.
              */
 			function addFormData(trackerInstance) {
 				// iterate through FORM elements
@@ -2175,9 +2176,14 @@ if (typeof window.Caliban !== 'object') {
 					formElements = documentAlias.forms,
 					formElement = null, trackerType = null;
 
+				configDebug && console.log('[CALIBAN_DEBUG] Forms found:', (formElements ? query.htmlCollectionToArray(formElements) : null));
+
 				if (formElements) {
 					for (i = 0; i < formElements.length; i++) {
 						formElement = formElements[i];
+
+						configDebug && console.log('[CALIBAN_DEBUG] Checking eligibility of form `' + (formElement.id || formElement.name) + '`');
+
 						if (!ignorePattern.test(formElement.className)) {
 							trackerType = typeof formElement.calibanTrackers;
 
@@ -2187,13 +2193,12 @@ if (typeof window.Caliban !== 'object') {
 								formElement.calibanTrackers = [];
 							}
 
-							if (-1 === indexOfArray(formElement.calibanTrackers, trackerInstance)) {
-								// we make sure to setup form only once for each tracker
-								formElement.calibanTrackers.push(trackerInstance);
+							// Add tracker to FORM for accessing API off element later
+							formElement.calibanTrackers.push(trackerInstance);
 
-								// Appened form params onInit and not onSubmit to allow working on forms
-								addFormParams(formElement);
-							}
+							// Appened form params as hidden elements
+							addFormParams(formElement);
+
 						} else {
 							configDebug && console.log('[CALIBAN_DEBUG] Ignoring form `' + (formElement.id || formElement.name) + '`');
 						}


### PR DESCRIPTION
- Calling `addFormData` via the JS API on a form added to the DOM after initial render did not work because the code copied from the link append was set to only run once. The form append would run and then try to fire a second time (after session data was sent back to the client) and the second call was ignored. No need to limit this as we should be able to modify the session and then force all forms to update.
- Fixes #11