### PR TITLE
Session last-attribution campaign model

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,11 +8,11 @@
     "packages": [
         {
             "name": "itcig/php-helpers",
-            "version": "v1.0.1",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/itcig/php-helpers.git",
-                "reference": "30dd0e78c8f45343916f94249a92a1628ea2cf4c"
+                "reference": "b3bdf77c1145c5d8dab3f5095b25d3fe744b7fe0"
             },
             "require": {
                 "php": "^7.1"
@@ -33,7 +33,7 @@
                 }
             ],
             "description": "PHP helper methods",
-            "time": "2020-03-26T03:39:23+00:00"
+            "time": "2020-03-30T03:11:09+00:00"
         },
         {
             "name": "oscarotero/env",
@@ -185,16 +185,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.14.0",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38"
+                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
-                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
+                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
                 "shasum": ""
             },
             "require": {
@@ -206,7 +206,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.14-dev"
+                    "dev-master": "1.15-dev"
                 }
             },
             "autoload": {
@@ -239,20 +239,34 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2020-01-13T11:15:53+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-02-27T09:26:54+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v4.1.2",
+            "version": "v4.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "939dfda2d7267ac8fc53ac3d642b5de357554c39"
+                "reference": "88f7acc95150bca002a498899f8b52f318e444c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/939dfda2d7267ac8fc53ac3d642b5de357554c39",
-                "reference": "939dfda2d7267ac8fc53ac3d642b5de357554c39",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/88f7acc95150bca002a498899f8b52f318e444c2",
+                "reference": "88f7acc95150bca002a498899f8b52f318e444c2",
                 "shasum": ""
             },
             "require": {
@@ -263,10 +277,12 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.3",
                 "ext-filter": "*",
+                "ext-pcre": "*",
                 "phpunit/phpunit": "^4.8.35 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "ext-filter": "Required to use the boolean validator."
+                "ext-filter": "Required to use the boolean validator.",
+                "ext-pcre": "Required to use most of the library."
             },
             "type": "library",
             "extra": {
@@ -301,7 +317,13 @@
                 "env",
                 "environment"
             ],
-            "time": "2020-03-12T13:44:15+00:00"
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/vlucas/phpdotenv",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-03-27T23:37:15+00:00"
         }
     ],
     "packages-dev": [],
@@ -313,5 +335,6 @@
     "platform": {
         "php": "^7.1"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/src/Caliban.php
+++ b/src/Caliban.php
@@ -20,13 +20,26 @@ require_once(__DIR__ . '/config.php');
 
 class Caliban extends Singleton {
 
-	// TODO: Move these all to config
 	const SESSION_REFERENCE_KEY = CBN_SESSION_REFERENCE_KEY;
 
 	const DEFAULT_CACHE_KEY = CBN_DEFAULT_CACHE_KEY;
 
 	// These have special uses and cannot be modified by any config
-	const STATIC_USE_PARAMS = ['gauid', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'];
+	const STATIC_USE_PARAMS = [
+		'gauid',
+		'utm_source',
+		'utm_medium',
+		'utm_campaign',
+		'utm_content',
+		'utm_term'
+	];
+
+	// Universally accepted campaign tracking params for Ad and analytics platforms that indicate inbound link should start a new session
+	const STATIC_CAMPAIGN_PARAMS = [
+		'utm_campaign', // UTM
+		'gclid', // AdWords auto-tagging
+		'msclkid' // Bing auto-tagging
+	];
 
 	private $client_uri;
 
@@ -46,11 +59,15 @@ class Caliban extends Singleton {
 
 	private $last_attribution_params;
 
+	private $campaign_start_params;
+
 	private $cache_key;
 
 	private $cache_expiration_seconds;
 
 	private $session_reference_id;
+
+	private $linked_sessions;
 
 	private $is_new_session;
 
@@ -150,6 +167,11 @@ class Caliban extends Singleton {
 		return $this;
 	}
 
+	/**
+	 * @param string $property_id Set a specific tracker property if running multiple trackers on the same page
+	 *
+	 * @return \Caliban\Caliban This class instance
+	 */
 	public function set_property_id(string $property_id): Caliban {
 		$this->property_id = $property_id;
 
@@ -161,8 +183,30 @@ class Caliban extends Singleton {
 	 *
 	 * @return Caliban This class instance
 	 */
-	public function set_session_reference_id(string $session_reference_id): Caliban {
+	public function set_session_reference_id(string $session_reference_id = null): Caliban {
+
+		// Build unique session identifier if not found
+		if (!$session_reference_id) {
+			$session_reference_id = bin2hex(version_compare(phpversion(), '7.0.0') >= 0
+				? random_bytes(10)
+				: openssl_random_pseudo_bytes(10)
+			);
+		}
+
+		// Set reference Id
 		$this->session_reference_id = $session_reference_id;
+
+		return $this;
+	}
+
+	/**
+	 * @param string $session_reference_id Pass in the session Id of a previously valid session to link to this session
+	 *
+	 * @return Caliban This class instance
+	 */
+	public function link_session_reference_id(string $session_reference_id = null): Caliban {
+		// Link another reference Id
+		$this->linked_sessions[] = $session_reference_id;
 
 		return $this;
 	}
@@ -187,6 +231,19 @@ class Caliban extends Singleton {
 	 */
 	public function set_ignore_params(array $keys): Caliban {
 		$this->ignore_params = array_merge($this->ignore_params, $keys);
+
+		return $this;
+	}
+
+	/**
+	 * Merge passed in campaign start params with defaults that are universal for Google or other ad platforms
+	 *
+	 * @param array $keys List of keys we should check for to signify the start of a new campaign/session in the request
+	 *
+	 * @return Caliban This class instance
+	 */
+	public function set_campaign_start_params(array $keys): Caliban {
+		$this->campaign_start_params = array_merge($this->campaign_start_params, $keys);
 
 		return $this;
 	}
@@ -229,7 +286,7 @@ class Caliban extends Singleton {
 	 */
 	private function set_defaults(): void {
 
-		// Assume a continuation of existing session unless passed as new.
+		// Assume new session unless determined otherwise
 		$this->is_new_session = false;
 
 		// Requesting URL
@@ -252,7 +309,17 @@ class Caliban extends Singleton {
 			$this->ignore_params = defined('CBN_IGNORE_PARAMS') ? CBN_IGNORE_PARAMS : [];
 		}
 
-		// Default list of params that are always first attribution without exception
+		// List keys that trigger a new campaign session even if a valid one exists (such as clicking on an Ad).
+		// This may seem redundant with "first attribution" list but you could have a key that should be set on an entry page,
+		// yet not important enough or due to backwards compatability exists throughout your funnel.
+		if (empty($this->campaign_start_params)) {
+			$this->campaign_start_params = array_merge(
+				(defined('CBN_CAMPAIGN_START_PARAMS') ? CBN_CAMPAIGN_START_PARAMS : []),
+				self::STATIC_CAMPAIGN_PARAMS
+				);
+		}
+
+		// List keys that are only set on a new session landing page and never mutated
 		if (empty($this->first_attribution_params)) {
 			$this->first_attribution_params = defined('CBN_FIRST_ATTRIBUTION_PARAMS') ? CBN_FIRST_ATTRIBUTION_PARAMS : [];
 		}
@@ -289,11 +356,7 @@ class Caliban extends Singleton {
 		// Build remainder of client query vars that are not ignored or set to first attribution
 		$last_attribution_filter_out_keys = array_merge(self::STATIC_USE_PARAMS,$this->first_attribution_params ?? [], $this->ignore_params ?? []);
 
-		foreach ($this->get_client_query_vars() as $available_query_key => $available_query_var) {
-			if (!in_array($available_query_key, $last_attribution_filter_out_keys)) {
-				$this->last_attribution_params[$available_query_key] = $available_query_var;
-			}
-		}
+		$this->last_attribution_params = array_values(array_diff(array_keys($this->get_client_query_vars()), $last_attribution_filter_out_keys));
 	}
 
 	private function init_storage(): void {
@@ -303,6 +366,15 @@ class Caliban extends Singleton {
 	}
 
 	/**
+	 * Create new Session Object or retrieve one from storage.
+	 *
+	 * For new sessions, the session Id may already have been set by the JS tracker or PHP client, but if not, it will be created in the request to get the Id.
+	 *
+	 * New sessions are determined either:
+	 *    - Explicitly
+	 *    - Based on presence of a "campaign start" parameter
+	 *
+	 *
 	 * @return Caliban This class instance
 	 */
 	public function init(): Caliban {
@@ -310,8 +382,16 @@ class Caliban extends Singleton {
 		// Initialize storage engine
 		$this->init_storage();
 
-		// Load cache data from existing session if exists
-		$cache_data = $this->load_session($this->cache_key) ?? "";
+		// Current unix timestamp which will be used multiple times below so grab once for consistentcy
+		$current_timestamp = time();
+
+		// Treat as new session if explicity set to true or this is determined to be the begnining of a new campaign
+		$this->is_new_session = $this->is_new_session || $this->is_campaign_start();
+
+		// Load cache data from existing session if exists and not a new session
+		$cache_data = $this->is_new_session
+			? ""
+			: ($this->load_session($this->cache_key) ?? "");
 
 		// Load previously stored cache data as previous state
 		$prev_state = SessionObject::fromString($cache_data);
@@ -319,14 +399,43 @@ class Caliban extends Singleton {
 		// Set previous state on class
 		$this->prev_state = $prev_state;
 
-		// Set up new session state starting from the previous state
+		// Set up new session state starting from the previous state (which may just be an empty Session Object.
 		$session_state = SessionObject::fromObject($prev_state);
+
+		// The JS client is setting a new session Id if it detects a new campaign and thus the previous session is unrecoverable because our session Id has changed.
+		// To see the transfer of a user to a new campaign, we can link this session to a previous one and store that data on the Session Object.
+		if ($this->is_new_session && !empty($this->linked_sessions)) {
+
+			// Start with previous linked session or create a new one that we'll attach to the current one
+			$linked_sessions_data = $prev_state->linked_sessions ?? [];
+
+			foreach($this->linked_sessions as $linked_session_id) {
+
+				// Load cache data from existing session if exists
+				$linked_cache_data = $this->load_session($this->cache_key, $linked_session_id) ?? "";
+
+				// Load linked container data
+				$linked_session = SessionObject::fromString($linked_cache_data);
+
+				// If a linked session is found and that session is valid by current expiration settings then attach previous campaign session as sub-key
+				if (!empty($linked_session->ts_updated) &&
+				    (time() - $linked_session->ts_updated) < $this->cache_expiration_seconds) {
+
+					// Remove any old sessions from the linked session object to avoid an infinite nesting scenario with huge objects.
+					// This would likely point to a bug and not useful data anyways and this is not the place to capture that.
+					unset($linked_session->linked_sessions);
+
+					$linked_sessions_data[] = $linked_session->toArray();
+				}
+			}
+		}
 
 		// Get passed params which are not designated for other purposes nor suppressed from tracker
 		$this->set_last_attribution_params();
 
 		// TODO: Parse inbound data to see if we can deduce Google/Bing/etc... when referrer is missing
 
+		// Create a debug record in the same storage container with a parallel key, but separate from the session data
 		if (CBN_DEBUG) {
 			$this->debug_state = SessionObject::fromArray([
 				'_id' => $this->get_session_reference_id(),
@@ -335,14 +444,27 @@ class Caliban extends Singleton {
 				'uri' => $this->client_uri,
 				'referrer' => $this->client_referrer,
 				'is_session_landing_page' => $this->is_session_landing_page(),
-				'new_session_test_1' => empty($this->get_client_querystring_value(self::SESSION_REFERENCE_KEY)),
-                'new_session_test_2' => (empty($this->get_client_cookie_value(self::SESSION_REFERENCE_KEY)) || $this->is_new_session),
+				'is_new_session' => $this->is_new_session,
+				'is_campaign_start' => $this->is_campaign_start(),
+				'new_session_test_url' => empty($this->get_client_querystring_value(self::SESSION_REFERENCE_KEY)),
+				'new_session_test_has_session_cookie' => empty($this->get_client_cookie_value(self::SESSION_REFERENCE_KEY)),
+				'new_session_test_no_cookie_or_not_new_session' => (empty($this->get_client_cookie_value(self::SESSION_REFERENCE_KEY)) || $this->is_new_session),
 				'ignore_params' => $this->ignore_params,
 				'append_params' => $this->append_params,
 				'first_attribution_params' => $this->first_attribution_params,
 				'last_attribution_params' => $this->last_attribution_params,
+				'campaign_start_params' => $this->campaign_start_params,
 				'client_query_vars' => $this->get_client_query_vars(),
 				'cookies' => array_keys($_COOKIE),
+				'servervars' => [
+					'HTTP_CLIENT_IP' => $_SERVER['HTTP_CLIENT_IP'],
+					'HTTP_X_REAL_IP' => $_SERVER['HTTP_X_REAL_IP'],
+					'HTTP_X_FORWARDED_FOR' => $_SERVER['HTTP_X_FORWARDED_FOR'],
+					'REMOTE_ADDR' => $_SERVER['REMOTE_ADDR'],
+					'HTTP_USER_AGENT' => $_SERVER['HTTP_USER_AGENT'],
+					'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+					'REQUEST_URI' => $_SERVER['REQUEST_URI'],
+				],
 			]);
 		}
 
@@ -354,17 +476,21 @@ class Caliban extends Singleton {
 		// This includes a return visit from an outside link or email even within the same session
 		if ($this->is_session_landing_page()) {
 
+			// Add Id to session data
+			$session_state->_id = $this->get_session_reference_id();
+
+			// Add created timestamp
+			$session_state->ts_created = $current_timestamp;
+
 			// Add referrer
 			$session_state->referrer = $this->client_referrer;
 
 			// Add current URI as the original page
 			$session_state->landing_uri = $this->client_uri;
 
-			// Check if GA UserId is already set
-			if (empty($prev_state->gauid)) {
-				// generate a new anonymous Id if no user is found
-				$session_state->gauid = $this->get_client_value('gauid', 'a_' . time() . mt_rand(1000000, 9999999));
-			}
+			// generate a new anonymous Id if no user is found
+			// TODO: Allow setting a sepcific GA user Id here or even better yet is this too sepcific and should be pre-set using a more generic setter?
+			$session_state->gauid = $this->get_client_value('gauid', array_column($linked_sessions, 'gauid')[0] ?? 'a_' . time() . mt_rand(1000000, 9999999));
 
 			// List of allowed UTM parameters
 			$utm_params = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'];
@@ -389,6 +515,11 @@ class Caliban extends Singleton {
 			foreach ($this->first_attribution_params as $first_attribution_param) {
 				$session_state->{$first_attribution_param} = $this->get_client_value($first_attribution_param);
 			}
+
+			// Attach linked sessions as last key on object
+			if (!empty($linked_sessions_data)) {
+				$session_state->linked_sessions = $linked_sessions_data;
+			}
 		}
 
 		//**************************************************************************
@@ -404,18 +535,16 @@ class Caliban extends Singleton {
 		// Set last URL visited
 		$session_state->last_uri = $this->client_uri;
 
+		// Modify updated timestamp which will be same as create for new sessions
+		$session_state->ts_updated = $current_timestamp;
+
+		// Duration of the session
+		$session_state->cbn_duration = ($session_state->ts_updated ?? $current_timestamp) - ($session_state->ts_created ?? $current_timestamp);
+
 		// Loop through last attribution keys and add/update
 		foreach ($this->last_attribution_params as $last_attribution_param) {
 			$session_state->{$last_attribution_param} = $this->get_client_value($last_attribution_param);
 		}
-
-		// NOTE: Unsure if this is needed at this point with current first/last attribution rules. Possibly limit the fields saved here to keep size down?
-		// Set `original` key on state if not set
-		// If session is brand new, this will equal the session values
-		// If session is recalled from storage it will either already have `original` key and use that or create a new one
-//		if (empty($session_state->original)) {
-//			$session_state->original = $session_state->toArray();
-//		}
 
 		// Set state
 		$this->state = $session_state;
@@ -464,12 +593,18 @@ class Caliban extends Singleton {
 	 * Load saved session data from datasource
 	 *
 	 * @param string $key The key containing the cache data value
+	 * @param string|null $session_reference_id Override the current session Id to retrieve a specific one (optional)
 	 *
 	 * @return string|null Session data
 	 */
-	public function load_session(string $key) : ?string {
+	public function load_session(string $key, ?string $session_reference_id = null) : ?string {
 
-		$cache_data = $this->storage_db->load($this->get_session_reference_id(), $key);
+		$cache_data = $this->storage_db->load($session_reference_id ?? $this->get_session_reference_id(), $key);
+
+		// If no stored data found thhen start new session
+//		if (empty($cache_data)) {
+//			$this->set_new_session(empty($cache_data));
+//		}
 
 		return $cache_data;
 	}
@@ -505,6 +640,7 @@ class Caliban extends Singleton {
 	 */
 	public function get_session_reference_id() : string {
 
+		// Return if already set
 		if (!empty($this->session_reference_id)) {
 			return $this->session_reference_id;
 		}
@@ -512,19 +648,11 @@ class Caliban extends Singleton {
 		// Attempt to retrieve existing cigsession reference Id
 		$session_reference_id = $this->get_client_value(self::SESSION_REFERENCE_KEY);
 
-		// Build unique session identifier if not found
-		if (!$session_reference_id) {
-			$session_reference_id = bin2hex(version_compare(phpversion(), '7.0.0') >= 0
-				? random_bytes(10)
-				: openssl_random_pseudo_bytes(10)
-			);
-		}
-
-		// Set reference Id
-		$this->session_reference_id = $session_reference_id;
+		// Set session Id, which will build unique session identifier if not found
+		$this->set_session_reference_id($session_reference_id);
 
 		// Return the Id
-		return $session_reference_id;
+		return $this->session_reference_id;
 	}
 
 	/**
@@ -535,7 +663,7 @@ class Caliban extends Singleton {
 
 		// To consider this the start of a new session:
 		// 1. The SESSION_REFERENCE_KEY was not passed in URL meaning we came from a session started on another domain
-		// 2. We do not have a session reference Id stored in a cookie AND not explictly marked as `new` which would indicate a client session just begain on the JS tracker
+		// 2. We do not have a session reference Id stored in a cookie AND not explictly marked as `new` which would indicate a client session was initiated or a campaign start param was received.
 		return empty($this->get_client_querystring_value(self::SESSION_REFERENCE_KEY)) &&
 		       (empty($this->get_client_cookie_value(self::SESSION_REFERENCE_KEY)) ||
 		        $this->is_new_session);
@@ -545,15 +673,23 @@ class Caliban extends Singleton {
 	}
 
 	/**
-	 * Check if session referrer is from a different domain that the client request
+	 * Check client URI to see if any "campaign" params exist which indicates we are starting a new campaign from an inbound link
+	 *
+	 * @return bool True if any campaign params are found in querystring
+	 */
+	private function is_campaign_start() {
+		return $this->client_querystring_contains($this->campaign_start_params);
+	}
+
+	/**
+	 * Check if session referrer is from a different domain than the client request
 	 *
 	 * TODO: What do we want to do if referrer is blank?
 	 *
 	 * @return bool True if domain does not match
 	 */
 	private function is_outside_referrer() {
-
-		return !\Cig\is_same_root_domain($this->client_referrer, $this->client_uri);
+		return !\Cig\is_same_hostname($this->client_referrer, $this->client_uri);
 	}
 
 	/**
@@ -593,6 +729,28 @@ class Caliban extends Singleton {
 		$query_vars = $this->get_client_query_vars();
 
 		return $query_vars[$key] ?? null;
+	}
+
+	/**
+	 * Check if client URI querystring contains a specific key or any of an array of keys
+	 *
+	 * @param $search string|array For string, match in querystring. For array, match any of the keys
+	 *
+	 * @return bool True if any matches are found
+	 */
+	private function client_querystring_contains($search): bool {
+
+		// Get all querystring params
+		$client_querystring_keys = array_keys($this->get_client_query_vars());
+
+		// If array is passed, see if any keys overlap with querystring params
+		if (is_array($search)) {
+			return count(array_intersect($search, $client_querystring_keys));
+
+		// Otherwise see if key passed is in querystring
+		} else {
+			return in_array($search, $client_querystring_keys);
+		}
 	}
 
 	/**

--- a/src/Server/Collect.php
+++ b/src/Server/Collect.php
@@ -8,8 +8,14 @@ require_once(__DIR__ . '/../config.php');
 
 class Collect extends Singleton {
 
+	/**
+	 * @var \Caliban\Caliban
+	 */
 	private $tracker;
-	
+
+	/**
+	 * @var array
+	 */
 	private $data;
 
 	public function set_data($request_vars) {
@@ -60,7 +66,14 @@ class Collect extends Singleton {
 				$this->tracker->set_session_reference_id($parsed_data[CBN_SESSION_REFERENCE_KEY]);
 			}
 
-			// Mark this as a brand new session if determined in tracker and passed in as `snew`
+			// Set the linked Session Reference Id when generated and passed back from the client
+			if (!empty($parsed_data['link_' . CBN_SESSION_REFERENCE_KEY])) {
+				$this->tracker->link_session_reference_id($parsed_data['link_' . CBN_SESSION_REFERENCE_KEY]);
+			}
+
+			// Mark this as a brand new session if determined in tracker and passed in as `snew`.
+			// Must pass a parameter for new session since the the cookie is already set, we may still be on the same domain
+			// and referer is unreliable, so any assumptions could be wrong.
 			if (isset($parsed_data['snew'])) {
 				$this->tracker->set_new_session(filter_var($parsed_data['snew'], FILTER_VALIDATE_BOOLEAN));
 			}

--- a/src/config.php
+++ b/src/config.php
@@ -93,3 +93,16 @@ if (!defined('CBN_FIRST_ATTRIBUTION_PARAMS') && !empty(env('CBN_FIRST_ATTRIBUTIO
 
 	define('CBN_FIRST_ATTRIBUTION_PARAMS', $first_attribution_params);
 }
+
+/**
+ * Campaign start params
+ */
+if (!defined('CBN_CAMPAIGN_START_PARAMS') && !empty(env('CBN_CAMPAIGN_START_PARAMS'))) {
+	// Convert to an array
+	$campaign_start_params = explode(",", env('CBN_CAMPAIGN_START_PARAMS'));
+
+	// Remove whitespace
+	array_walk($campaign_start_params, 'trim');
+
+	define('CBN_CAMPAIGN_START_PARAMS', $campaign_start_params);
+}


### PR DESCRIPTION
- Reset session when entering with a campaign start parameter such as `utm_campaign`, common Ad network auto tags or custom params. Referrer is not reliable so simply relying on a blank campaign or missing session Id does not always indicate a new session.
- Allow linking previous session as a sub-key on session data to see when a new campaign starts
- Added additional meta to session data and debug objects
- Resolves #13